### PR TITLE
Add setting to search for keywords any language supported by Pexels API

### DIFF
--- a/pexels_fsp_images.js
+++ b/pexels_fsp_images.js
@@ -4,15 +4,20 @@
     No user action required upon installation.
 */
 function call_api(q, p){
+    var locale = OPTIONS.searchLocale;
+    var query = 'https://api.pexels.com/v1/search?query='+encodeURIComponent(q)+'&per_page='+per_page+'&page='+p;
+    if (locale) {
+        query += '&locale='+locale;
+    }
+
     var xhr = new XMLHttpRequest();
-    var locale = "de-DE"
-    xhr.open('GET', 'https://api.pexels.com/v1/search?query='+encodeURIComponent(q)+'&per_page='+per_page+'&page='+p+'&locale='+locale);
-        xhr.setRequestHeader('Authorization', '563492ad6f91700001000001a626f8ddac7d48a88fc0856cb7622195');
-    xhr.onreadystatechange = function(){
+    xhr.open('GET', query);
+    xhr.setRequestHeader('Authorization', '563492ad6f91700001000001a626f8ddac7d48a88fc0856cb7622195');
+    xhr.onreadystatechange = function() {
         if (this.status == 200 && this.readyState == 4) {
             var data = JSON.parse(this.responseText);
             if (!(data.total_results > 0)) {
-                jQuery('#pexels_fsp_results').html('<div style="color:#bbb;font-size:24px;text-align:center;margin:40px 0">——No matches——</div>');
+                jQuery('#pexels_fsp_results').html('<div style="color:#bbb;font-size:24px;text-align:center;margin:40px 0">No matches</div>');
                 return false;
             }
             render_px_results(q, p, data);

--- a/pexels_fsp_images.js
+++ b/pexels_fsp_images.js
@@ -1,0 +1,23 @@
+/*
+    Initiate the call to the Pexels API (https://www.pexels.com/api/)
+    An API key is provided upon request, hence hardcoded here.
+    No user action required upon installation.
+*/
+function call_api(q, p){
+    var xhr = new XMLHttpRequest();
+    var locale = "de-DE"
+    xhr.open('GET', 'https://api.pexels.com/v1/search?query='+encodeURIComponent(q)+'&per_page='+per_page+'&page='+p+'&locale='+locale);
+        xhr.setRequestHeader('Authorization', '563492ad6f91700001000001a626f8ddac7d48a88fc0856cb7622195');
+    xhr.onreadystatechange = function(){
+        if (this.status == 200 && this.readyState == 4) {
+            var data = JSON.parse(this.responseText);
+            if (!(data.total_results > 0)) {
+                jQuery('#pexels_fsp_results').html('<div style="color:#bbb;font-size:24px;text-align:center;margin:40px 0">——No matches——</div>');
+                return false;
+            }
+            render_px_results(q, p, data);
+        }
+    };
+    xhr.send();
+    return false;
+}

--- a/settings.php
+++ b/settings.php
@@ -8,6 +8,11 @@
 
 wp_enqueue_script( 'pexels_fsp_images_script', plugin_dir_url(__FILE__) . 'pexels_fsp_images.js' );
 
+$options = get_option('pexels_fsp_images_options');
+wp_add_inline_script( 'pexels_fsp_images_script', 'const OPTIONS = ' . json_encode( array(
+    'searchLocale' => $options['search_locale'],
+) ), 'before' );
+
 /* Add the menu */
 
 function add_admin_menu() {
@@ -30,6 +35,13 @@ function register_pexels_fsp_images_options(){
     register_setting('pexels_fsp_images_options', 'pexels_fsp_images_options', 'pexels_fsp_images_options_validate');
     add_settings_section('pexels_fsp_images_options_section', '', '', 'pexels_fsp_images_settings');
     add_settings_field('attribution-id', __('Attribution', 'pexels_fsp_images'), 'pexels_fsp_images_render_attribution', 'pexels_fsp_images_settings', 'pexels_fsp_images_options_section');
+    add_settings_field(
+        'search-locale-id', // ID
+        __( 'Search locale', 'pexels_fsp_images' ), // Title
+        'pexels_fsp_images_render_search_locale', // Callback
+        'pexels_fsp_images_settings', // Page
+        'pexels_fsp_images_options_section' // Section
+    );
 }
 
 /* Attribution field */
@@ -39,6 +51,14 @@ function pexels_fsp_images_render_attribution(){
     echo '<label><input name="pexels_fsp_images_options[attribution]" value="true" type="checkbox"'.(!$options['attribution'] | $options['attribution']=='true'?' checked="checked"':'').'> '.__('Automatically insert image captions with attribution.', 'pexels_fsp_images').'</label>';
 }
 
+/* Get the settings option array and print one of its values */
+function pexels_fsp_images_render_search_locale() {
+    $options = get_option('pexels_fsp_images_options');
+    printf(
+        '<input type="text" id="search_locale" name="pexels_fsp_images_options[search_locale]" value="%s" />',
+        isset( $options['search_locale'] ) ? esc_attr( $options['search_locale'] ) : ''
+    );
+}
 
 /* The actions inside the iframe i.e. the works!
  ** The function must begin with "media_" so wp_iframe() adds media css styles)
@@ -172,6 +192,10 @@ function pexels_fsp_images_options_validate($input){
     global $pexels_fsp_images_gallery_languages;
     $options = get_option('pexels_fsp_images_options');
     if ($input['attribution']) $options['attribution'] = 'true'; else $options['attribution'] = 'false';
+
+    if( isset( $input['search_locale'] ) )
+        $options['search_locale'] = sanitize_text_field( $input['search_locale'] );
+
     return $options;
 }
 

--- a/settings.php
+++ b/settings.php
@@ -89,7 +89,8 @@ function media_pexels_fsp_images_tab() {
 		 */
 	   function call_api(q, p){
 	     var xhr = new XMLHttpRequest();
-	     xhr.open('GET', 'https://api.pexels.com/v1/search?query='+encodeURIComponent(q)+'&per_page='+per_page+'&page='+p);
+		 var locale = "de-DE"
+	     xhr.open('GET', 'https://api.pexels.com/v1/search?query='+encodeURIComponent(q)+'&per_page='+per_page+'&page='+p+'&locale='+locale);
 			 xhr.setRequestHeader('Authorization', '563492ad6f91700001000001a626f8ddac7d48a88fc0856cb7622195');
 	     xhr.onreadystatechange = function(){
 	       if (this.status == 200 && this.readyState == 4) {
@@ -216,7 +217,7 @@ if (isset($_POST['pexels_fsp_upload'])) {
 		die('Error: ' . $response->get_error_message());
 
 	$q_tags = explode(' ', sanitize_text_field($_POST['q']));
-	array_splice($q_tags, 2);
+	array_splice($q_tags, 3);
 	foreach ($q_tags as $k => $v) {
 		// remove ../../../..
 		$v          = str_replace("..", "", $v);

--- a/settings.php
+++ b/settings.php
@@ -6,6 +6,8 @@
 	Author: Raaj Trambadia (https://raajtram.com)
 */
 
+wp_enqueue_script( 'pexels_fsp_images_script', plugin_dir_url(__FILE__) . 'pexels_fsp_images.js' );
+
 /* Add the menu */
 
 function add_admin_menu() {
@@ -82,31 +84,8 @@ function media_pexels_fsp_images_tab() {
 	       jQuery('#pexels_fsp_results').html('');
 	       call_api(q, 1);
 	   });
-		 /*
-		 		Initiate the call to the Pexels API (https://www.pexels.com/api/)
-				An API key is provided upon request, hence hardcoded here.
-				No user action required upon installation.
-		 */
-	   function call_api(q, p){
-	     var xhr = new XMLHttpRequest();
-		 var locale = "de-DE"
-	     xhr.open('GET', 'https://api.pexels.com/v1/search?query='+encodeURIComponent(q)+'&per_page='+per_page+'&page='+p+'&locale='+locale);
-			 xhr.setRequestHeader('Authorization', '563492ad6f91700001000001a626f8ddac7d48a88fc0856cb7622195');
-	     xhr.onreadystatechange = function(){
-	       if (this.status == 200 && this.readyState == 4) {
-	           var data = JSON.parse(this.responseText);
-	           if (!(data.total_results > 0)) {
-	               jQuery('#pexels_fsp_results').html('<div style="color:#bbb;font-size:24px;text-align:center;margin:40px 0">—— <?= _e('No matches', 'pexels_fsp_images') ?> ——</div>');
-	               return false;
-	           }
-	           render_px_results(q, p, data);
-	       }
-	     };
-	     xhr.send();
-	     return false;
-	   }
 
-	   function render_px_results(q, p, data){
+       function render_px_results(q, p, data){
 		 	 /* store for upload click */
 	     photos = data['photos'];
 			 /* pagination */


### PR DESCRIPTION
Enter e.g. 'de-DE' into the search locale field to use German keywords.

For other supported languages, look at the Pexels API Documentation
https://www.pexels.com/api/documentation/#photos-search__locale